### PR TITLE
Fix "Task 'first_scan_filesystem' already exists"

### DIFF
--- a/addons/globalize-plugins/plugin.gd
+++ b/addons/globalize-plugins/plugin.gd
@@ -86,7 +86,8 @@ func globalize_local_plugins():
 	var rfs := EditorInterface.get_resource_filesystem()
 	await get_tree().process_frame
 	#print('scan 1')
-	rfs.scan()
+	if not rfs.is_scanning():
+		rfs.scan()
 	
 	while rfs.is_scanning():
 		#print('waiting while scanning')


### PR DESCRIPTION
Avoids the following errors/warnings at startup:

```
ERROR: Task 'first_scan_filesystem' already exists.
   at: (editor/gui/progress_dialog.cpp:199)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "p_enabled && addon_name_to_plugin.has(addon_path)" is true.
   at: set_addon_plugin_enabled (editor/editor_node.cpp:4304)
   GDScript backtrace (most recent call first):
       [0] globalize_local_plugins (res://addons/globalize-plugins/plugin.gd:89)
ERROR: Condition "!tasks.has(p_task)" is true.
   at: end_task (editor/gui/progress_dialog.cpp:253)
ERROR: Condition "thread.is_started()" is true.
   at: scan (editor/file_system/editor_file_system.cpp:1114)
```